### PR TITLE
encoder: optimize

### DIFF
--- a/encode_test.go
+++ b/encode_test.go
@@ -33,6 +33,9 @@ func TestEncoder_Reset(t *testing.T) {
 		"content":   true,
 		"blockSize": true,
 
+		// Safe to ignore, since it's always reset before being used.
+		"blakeHasher": true,
+
 		// Checked below
 		"splitter": true,
 	})


### PR DESCRIPTION
Reuse the splitter buffer instead of allocating, and cache a blake2b hasher so we don't construct a new hash.Hash every time we encrypt a data block.

Benchmarks show that this results in about a +10% gain in B/s and a 10% improvement in sec/op.